### PR TITLE
Fix order of multiple attachers in mdast.use

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,9 +153,9 @@ function use(attach, options) {
      */
 
     if ('length' in attach && typeof attach !== 'function') {
-        index = attach.length;
+        index = -1;
 
-        while (attach[--index]) {
+        while (attach[++index]) {
             self.use(attach[index]);
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -485,6 +485,18 @@ describe('mdast.use(plugin, options?)', function () {
         mdast.use([function () {}, function () {}]);
     });
 
+    it('should attach multiple attachers in the correct order', function () {
+        var order = [];
+
+        mdast.use([function () {
+            order.push(1);
+        }, function () {
+            order.push(2);
+        }]);
+
+        assert.deepEqual(order, [1, 2]);
+    });
+
     it('should return an instance of mdast', function () {
         var processor = mdast.use(noop);
 


### PR DESCRIPTION
This patch changes the order in which multiple attachers (passed in array) are attached in `mdast.use`.

```
mdast.use([plugin1, plugin2, plugin3])
```

becomes equivalent to

```
mdast.use(plugin1).use(plugin2).use(plugin3)
```

Close #37.