### PR TITLE
demo: fix label on settings toggle

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -227,7 +227,7 @@ function onintenttoggelsettings() {
     var hidden = $settings.classList.contains('hidden');
 
     $settings.classList[hidden ? 'remove' : 'add']('hidden');
-    $toggleSettings.textContent = (hidden ? 'Show' : 'Hide') + ' settings';
+    $toggleSettings.textContent = (hidden ? 'Hide' : 'Show') + ' settings';
 }
 
 function onintentclear() {


### PR DESCRIPTION
Previously "Show settings" and "Hide settings" labels were mixed up.