### PR TITLE
Make node argument to entities encoder optional

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -261,7 +261,7 @@ function encodeFactory(type, file) {
      *   encode('AT&T'); // 'ATT&#x26;T'
      *
      * @param {string} value - Content.
-     * @param {Object} node - Node which is compiled.
+     * @param {Object} [node] - Node which is compiled.
      * @return {string} - Encoded content.
      * @throws {Error} - When `file.quiet` is not `true`.
      *   However, by default `he` does not throw on
@@ -273,7 +273,7 @@ function encodeFactory(type, file) {
         try {
             return he[fn](value, options);
         } catch (exception) {
-            file.fail(exception, node.position);
+            file.fail(exception, node ? node.position : null);
         }
     }
 


### PR DESCRIPTION
As outlined in https://github.com/wooorm/mdast/pull/78#issuecomment-147898607, mdast's markdown compiler [exposes][3] `this.encode` method which is used by [other][1] [compilers][2] internally to encode HTML entities.

However, existing compiler plugins pass only one argument to `this.encode` — text string which they have to encode, but currently `this.encode` expects two arguments and may even [fail][4] abruptly in some cases (although probably very rare or impossible in practice).

Luckily, the only thing that needs this argument in `this.encode` is a call to [VFile#fail][5] where `node.position` is passed as a second argument, which is optional according to vfile API.

This patch makes the second argument to `this.encode` in a compiler instance optional.

[1]: https://github.com/wooorm/mdast-html/blob/4315c6e95cf64027890ea4da79ec71ab76071eca/lib/compilers.js#L602
[2]: https://github.com/wooorm/mdast-man/blob/101df38d30ac78fe49e66a94b306e5dfc541905a/lib/compilers.js#L268
[3]: https://github.com/wooorm/mdast/blob/0ec8dede49e7c7f5433531408ddcd0e7d7ada772/lib/stringify.js#L463
[4]: https://github.com/wooorm/mdast/blob/0ec8dede49e7c7f5433531408ddcd0e7d7ada772/lib/stringify.js#L276
[5]: https://github.com/wooorm/vfile#vfilefailreason-position