### PR TITLE
cli: don't check for plugins key recursively

### DIFF
--- a/lib/cli/configuration.js
+++ b/lib/cli/configuration.js
@@ -66,7 +66,7 @@ extend(base.settings, defaults.stringify);
  * @param {Object} configuration - Configuration to merge from.
  * @return {Object} - `target`.
  */
-function merge(target, configuration) {
+function merge(target, configuration, recursive) {
     var key;
     var value;
     var index;
@@ -78,7 +78,7 @@ function merge(target, configuration) {
             value = configuration[key];
             result = target[key];
 
-            if (key === PLUGIN_KEY) {
+            if (key === PLUGIN_KEY && !recursive) {
                 if (!result) {
                     result = {};
 
@@ -95,13 +95,13 @@ function merge(target, configuration) {
                         }
                     }
                 } else {
-                    target[key] = merge(result || {}, value);
+                    target[key] = merge(result, value, true);
                 }
             } else if (typeof value === 'object' && value !== null) {
                 if ('length' in value) {
                     target[key] = concat.apply(value);
                 } else {
-                    target[key] = merge(result || {}, value);
+                    target[key] = merge(result || {}, value, true);
                 }
             } else if (value !== undefined) {
                 target[key] = value;


### PR DESCRIPTION
Previously, configuration merger would turn all "plugins" arrays into objects, even inside plugin option objects. This patch checks for this property only at the top scope and not recursively.

Fix #99.