### PR TITLE
Add link to mdast-util-inject

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -124,7 +124,6 @@ working with the [AST](https://github.com/wooorm/mdast/blob/master/doc/mdastnode
 *   [wooorm/mdast-util-to-string](https://github.com/wooorm/mdast-util-to-string)
     — Get the plain text content of a node.
 
-
 In addition, see [`unist`](https://github.com/wooorm/unist#unist-node-utilties)
 for other utilities which work with **mdast** nodes, but also with
 [retext](https://github.com/wooorm/retext) nodes.

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -115,11 +115,15 @@ working with the [AST](https://github.com/wooorm/mdast/blob/master/doc/mdastnode
 *   [wooorm/mdast-util-heading-style](https://github.com/wooorm/mdast-util-heading-style)
     — Get the style of a heading (`"atx"`, `"atx-closed"`, or `"setext"`);
 
+*   [anandthakker/mdast-util-inject](https://github.com/anandthakker/mdast-util-inject)
+    - Inject one AST into another at a specified heading, keeping heading structure intact;
+
 *   [wooorm/mdast-util-position](https://github.com/wooorm/mdast-util-position)
     — Get the position of nodes;
 
 *   [wooorm/mdast-util-to-string](https://github.com/wooorm/mdast-util-to-string)
     — Get the plain text content of a node.
+
 
 In addition, see [`unist`](https://github.com/wooorm/unist#unist-node-utilties)
 for other utilities which work with **mdast** nodes, but also with


### PR DESCRIPTION
Inserted it in alpha order by the package name, since they already seemed to be ordered that way.